### PR TITLE
Add support for NPM packaging and use as a node module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bower_components/*
+node_modules/
 README.html

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ repository to your `bower.json` file:
 
 Then a quick `bower install` is all you need.
 
+### Using NPM
+
+If you are using NPM to manage your Javascript dependecies, just install the artifact with --save-dev flag:
+
+```npm install jasmine-data_driven_tests --save-dev```
+
 ### Manual Installation
 
 Just download the latest or clone this repository:
@@ -47,7 +53,20 @@ Just download the latest or clone this repository:
 
 ## Getting Started
 
-Simply include `src/all.js` after the source files for Jasmine. Now, you have
+In browser environment simply include `src/all.js` after the source files for Jasmine.
+
+In node environment require the module before your suite.
+
+```javascript
+'use strict';
+var service;
+require('jasmine-data_driven_tests');
+service = require('my-shiny-new-service');
+
+describe(description, dataset, callback);
+```
+
+Now, you have
 two global functions available to you:
 
 Data Driven Tests:

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
 	"name": "jasmine-data_driven_tests",
 	"description": "This plugin for Jasmine 2.x allows you to easily create data driven tests.",
-	"version": "1.1.1",
+	"version": "1.2.0",
 	"homepage": "https://github.com/gburghardt/jasmine-data_driven_tests",
 	"authors": [
 		"Greg Burghardt <greg_burghardt@yahoo.com>"

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+module.exports = require('./src/all.js');
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "jasmine-data_driven_tests",
+  "version": "1.1.1",
+  "description": "This plugin for Jasmine 2.x allows you to easily create data driven tests.",
+  "main": "index.js",
+  "scripts": {
+    "test": "jasmine"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gburghardt/jasmine-data_driven_tests.git"
+  },
+  "author": "Greg Burghardt <greg_burghardt@yahoo.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gburghardt/jasmine-data_driven_tests/issues"
+  },
+  "homepage": "https://github.com/gburghardt/jasmine-data_driven_tests#readme",
+  "dependencies": {
+    "jasmine": "^2.0.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jasmine-data_driven_tests",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "This plugin for Jasmine 2.x allows you to easily create data driven tests.",
   "main": "index.js",
   "scripts": {

--- a/src/all.js
+++ b/src/all.js
@@ -5,6 +5,11 @@
 var root = this,
     toString = Object.prototype.toString;
 
+if (typeof module !== 'undefined' && module.exports && typeof exports !== 'undefined') {
+  if (typeof global !== 'undefined') {
+    root = global;
+  }
+}
 function all(description, dataset, fn) {
 	return createDataDrivenSpecs(root.it, description, dataset, fn, true);
 }


### PR DESCRIPTION
Updated `all.js` to detect whether running in a `node` environment. If `node` environment is detected then assigns `root` to the `global` object.

``` javascript
if (typeof module !== 'undefined' && module.exports && typeof exports !== 'undefined') {
  if (typeof global !== 'undefined') {
    root = global;
  }
}
```
